### PR TITLE
Remove breadcrumb links and Python 2 references. Set to v3.6.1

### DIFF
--- a/hello_world.ipynb
+++ b/hello_world.ipynb
@@ -11,17 +11,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Python world!\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "print('Hello Python world!')"
    ]
@@ -30,40 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: If you are using Python 2.7, this would be:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Python world!\n"
-     ]
-    }
-   ],
-   "source": [
-    "print \"Hello Python world!\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "If it works, congratulations! You just ran your first Python program."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- - -\n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) | \n",
-    "[Next: Variables, Strings, and Numbers](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/var_string_num.ipynb)"
    ]
   }
  ],
@@ -83,7 +44,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/if_statements.ipynb
+++ b/if_statements.ipynb
@@ -13,15 +13,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Previous: Introducing Functions](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/introducing_functions.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) |\n",
-    "[Next: While Loops and Input](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/while_input.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Contents\n",
     "===\n",
     "- [What is an *if* statement?](#What-is-an-*if*-statement?)\n",
@@ -57,22 +48,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I like ice cream.\n",
-      "I like chocolate.\n",
-      "Apple Crisp is my favorite dessert!\n",
-      "I like cookies.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# A list of desserts I like.\n",
     "desserts = ['ice cream', 'chocolate', 'apple crisp', 'cookies']\n",
@@ -146,176 +126,88 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "5 == 5"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "3 == 5 "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "5 == 5.0"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "'eric' == 'eric'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "'Eric' == 'eric'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "'Eric'.lower() == 'eric'.lower()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "'5' == 5"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "'5' == str(5)"
    ]
@@ -340,66 +232,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "3 != 5"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "5 != 5"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "'Eric' != 'eric'"
    ]
@@ -422,22 +281,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "5 > 3"
    ]
@@ -451,44 +299,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "5 >= 3"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "3 >= 3"
    ]
@@ -502,22 +328,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "3 < 5"
    ]
@@ -531,44 +346,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "3 <= 5"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "3 <= 3"
    ]
@@ -591,22 +384,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "vowels = ['a', 'e', 'i', 'o', 'u']\n",
     "'a' in vowels"
@@ -614,22 +396,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "vowels = ['a', 'e', 'i', 'o', 'u']\n",
     "'b' in vowels"
@@ -674,19 +445,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Wow, we have a lot of dogs here!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['willie', 'hootz', 'peso', 'juno']\n",
     "\n",
@@ -703,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -734,19 +497,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Wow, we have a lot of dogs here!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['willie', 'hootz', 'peso', 'juno']\n",
     "\n",
@@ -765,19 +520,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Okay, this is a reasonable number of dogs.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2]\n",
     "dogs = ['willie', 'hootz']\n",
@@ -808,19 +555,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Holy mackerel, we might as well start a dog hostel!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['willie', 'hootz', 'peso', 'monty', 'juno', 'turkey']\n",
     "\n",
@@ -841,19 +580,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Wow, we have a lot of dogs here!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2]\n",
     "dogs = ['willie', 'hootz', 'peso', 'monty']\n",
@@ -875,19 +606,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Okay, this is a reasonable number of dogs.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2]\n",
     "dogs = ['willie', 'hootz']\n",
@@ -909,19 +632,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Okay, this is a reasonable number of dogs.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2]\n",
     "dogs = []\n",
@@ -943,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -969,19 +684,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I wish we had a dog here.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[10,11]\n",
     "dogs = []\n",
@@ -1056,20 +763,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello, Willie!\n",
-      "Hello, Hootz!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['willie', 'hootz']\n",
     "\n",
@@ -1092,19 +790,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello, Willie!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[6,7,8,9,10,11]\n",
     "dogs = ['willie', 'hootz']\n",
@@ -1128,20 +818,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello, Willie!\n",
-      "Hello, Hootz!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs_we_know = ['willie', 'hootz', 'peso', 'monty', 'juno', 'turkey']\n",
     "dogs_present = ['willie', 'hootz']\n",
@@ -1177,19 +858,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to False.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2]\n",
     "if 0:\n",
@@ -1200,19 +873,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to True.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2]\n",
     "if 1:\n",
@@ -1223,19 +888,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to True.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# Arbitrary non-zero numbers evaluate to True.\n",
@@ -1247,19 +904,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to True.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# Negative numbers are not zero, so they evaluate to True.\n",
@@ -1271,19 +920,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to False.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# An empty string evaluates to False.\n",
@@ -1295,19 +936,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to True.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# Any other string, including a space, evaluates to True.\n",
@@ -1319,19 +952,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to True.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# Any other string, including a space, evaluates to True.\n",
@@ -1343,19 +968,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This evaluates to False.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# None is a special object in Python. It evaluates to False.\n",
@@ -1391,16 +1008,6 @@
    "metadata": {},
    "source": [
     "[top](#)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- - -\n",
-    "[Previous: Introducing Functions](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/introducing_functions.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) |\n",
-    "[Next: While Loops and Input](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/while_input.ipynb)"
    ]
   },
   {

--- a/introducing_functions.ipynb
+++ b/introducing_functions.ipynb
@@ -15,15 +15,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Previous: Lists and Tuples](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/lists_tuples.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) |\n",
-    "[Next: If Statements](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/if_statements.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Contents\n",
     "===\n",
     "- [What are functions?](#What-are-functions)\n",
@@ -108,26 +99,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You are doing good work, Adriana!\n",
-      "Thank you very much for your efforts on this project.\n",
-      "\n",
-      "You are doing good work, Billy!\n",
-      "Thank you very much for your efforts on this project.\n",
-      "\n",
-      "You are doing good work, Caroline!\n",
-      "Thank you very much for your efforts on this project.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"You are doing good work, Adriana!\")\n",
     "print(\"Thank you very much for your efforts on this project.\")\n",
@@ -148,27 +124,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "You are doing good work, Adriana!\n",
-      "Thank you very much for your efforts on this project.\n",
-      "\n",
-      "You are doing good work, Billy!\n",
-      "Thank you very much for your efforts on this project.\n",
-      "\n",
-      "You are doing good work, Caroline!\n",
-      "Thank you very much for your efforts on this project.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def thank_you(name):\n",
     "    # This function prints a two-line personalized thank you message.\n",
@@ -201,22 +161,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'thank_you' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-1-a1b6b8373f44>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mthank_you\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'Adriana'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[0mthank_you\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'Billy'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[0mthank_you\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'Caroline'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0mthank_you\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mNameError\u001b[0m: name 'thank_you' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "thank_you('Adriana')\n",
     "thank_you('Billy')\n",
@@ -248,27 +197,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Our students are currently in alphabetical order.\n",
-      "Aaron\n",
-      "Bernice\n",
-      "Cody\n",
-      "\n",
-      "Our students are now in reverse alphabetical order.\n",
-      "Cody\n",
-      "Bernice\n",
-      "Aaron\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "students = ['bernice', 'aaron', 'cody']\n",
     "\n",
@@ -298,27 +231,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Our students are currently in alphabetical order.\n",
-      "Aaron\n",
-      "Bernice\n",
-      "Cody\n",
-      "\n",
-      "Our students are now in reverse alphabetical order.\n",
-      "Cody\n",
-      "Bernice\n",
-      "Aaron\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3,4,5,6,12,16]\n",
     "def show_students(students, message):\n",
@@ -365,27 +282,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Our students are currently in alphabetical order.\n",
-      "- Aaron\n",
-      "- Bernice\n",
-      "- Cody\n",
-      "\n",
-      "Our students are now in reverse alphabetical order.\n",
-      "- Cody\n",
-      "- Bernice\n",
-      "- Aaron\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def show_students(students, message):\n",
     "    # Print out a message, and then the list of students\n",
@@ -422,22 +323,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 None\n",
-      "1 one\n",
-      "2 two\n",
-      "3 three\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def get_number_word(number):\n",
     "    # Takes in a numerical value, and returns\n",
@@ -467,24 +357,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 zero\n",
-      "1 one\n",
-      "2 two\n",
-      "3 three\n",
-      "4 I'm sorry, I don't know that number.\n",
-      "5 I'm sorry, I don't know that number.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[13,14,17]\n",
     "def get_number_word(number):\n",
@@ -516,24 +393,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 zero\n",
-      "1 one\n",
-      "2 two\n",
-      "3 three\n",
-      "4 I'm sorry, I don't know that number.\n",
-      "5 I'm sorry, I don't know that number.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[16,17,18]\n",
     "def get_number_word(number):\n",
@@ -632,16 +496,6 @@
    "metadata": {},
    "source": [
     "[top](#)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- - -\n",
-    "[Previous: Lists and Tuples](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/lists_tuples.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) |\n",
-    "[Next: If Statements](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/if_statements.ipynb)"
    ]
   },
   {

--- a/lists_tuples.ipynb
+++ b/lists_tuples.ipynb
@@ -13,15 +13,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Previous: Variables, Strings, and Numbers](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/var_string_num.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) | \n",
-    "[Next: Introducing Functions](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/introducing_functions.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Contents\n",
     "===\n",
     "- [Lists](#Lists)\n",
@@ -103,21 +94,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello, Bernice!\n",
-      "Hello, Aaron!\n",
-      "Hello, Cody!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "students = ['bernice', 'aaron', 'cody']\n",
     "\n",
@@ -160,19 +141,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Border Collie\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "\n",
@@ -189,19 +162,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Australian Cattle Dog\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[4]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -220,19 +185,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Labrador Retriever\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[4]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -250,19 +207,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Australian Cattle Dog\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[4]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -280,22 +229,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "IndexError",
-     "evalue": "list index out of range",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-33-32c58df001ad>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mdogs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m'border collie'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'australian cattle dog'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'labrador retriever'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mdog\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdogs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m4\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdog\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtitle\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[4]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -359,21 +297,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "border collie\n",
-      "australian cattle dog\n",
-      "labrador retriever\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "\n",
@@ -409,21 +337,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I like border collies.\n",
-      "I like australian cattle dogs.\n",
-      "I like labrador retrievers.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[5]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -445,29 +363,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I like border collies.\n",
-      "No, I really really like border collies!\n",
-      "\n",
-      "I like australian cattle dogs.\n",
-      "No, I really really like australian cattle dogs!\n",
-      "\n",
-      "I like labrador retrievers.\n",
-      "No, I really really like labrador retrievers!\n",
-      "\n",
-      "\n",
-      "That's just how I feel about dogs.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[6,7,8]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -504,23 +404,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results for the dog show are as follows:\n",
-      "\n",
-      "Place: 0 Dog: Border Collie\n",
-      "Place: 1 Dog: Australian Cattle Dog\n",
-      "Place: 2 Dog: Labrador Retriever\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "\n",
@@ -551,23 +439,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results for the dog show are as follows:\n",
-      "\n",
-      "Place: 1 Dog: Border Collie\n",
-      "Place: 2 Dog: Australian Cattle Dog\n",
-      "Place: 3 Dog: Labrador Retriever\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[6]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -588,21 +464,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['border collie', 'australian cattle dog', 'labrador retriever']\n",
-      "['border collie', 'australian cattle dog', 'labrador retriever']\n",
-      "['border collie', 'australian cattle dog', 'labrador retriever']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[5]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -620,22 +486,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "Can't convert 'list' object to str implicitly",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-20-8e7acc74d7a9>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mdog\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdogs\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'I like '\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mdogs\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;34m's.'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m: Can't convert 'list' object to str implicitly"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[5]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -687,19 +542,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['australian shepherd', 'australian cattle dog', 'labrador retriever']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "\n",
@@ -718,19 +565,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "\n",
@@ -746,22 +585,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "'poodle' is not in list",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-13-a9e05e37e8df>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mdogs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m'border collie'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'australian cattle dog'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'labrador retriever'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdogs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'poodle'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m: 'poodle' is not in list"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[4]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -780,20 +608,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "True\n",
-      "False\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "\n",
@@ -813,22 +632,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Border Collies are cool.\n",
-      "Australian Cattle Dogs are cool.\n",
-      "Labrador Retrievers are cool.\n",
-      "Poodles are cool.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "dogs.append('poodle')\n",
@@ -847,19 +655,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['border collie', 'poodle', 'australian cattle dog', 'labrador retriever']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "dogs.insert(1, 'poodle')\n",
@@ -889,21 +689,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Welcome, Bernice!\n",
-      "Welcome, Cody!\n",
-      "Welcome, Aaron!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create an empty list to hold our users.\n",
     "usernames = []\n",
@@ -927,24 +717,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Welcome, Bernice!\n",
-      "Welcome, Cody!\n",
-      "Welcome, Aaron!\n",
-      "\n",
-      "Thank you for being our very first user, Bernice!\n",
-      "And a warm welcome to our newest user, Aaron!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[10,11,12]\n",
     "# Create an empty list to hold our users.\n",
@@ -982,27 +759,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Our students are currently in alphabetical order.\n",
-      "Aaron\n",
-      "Bernice\n",
-      "Cody\n",
-      "\n",
-      "Our students are now in reverse alphabetical order.\n",
-      "Cody\n",
-      "Bernice\n",
-      "Aaron\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "students = ['bernice', 'aaron', 'cody']\n",
     "\n",
@@ -1033,32 +794,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Here is the list in alphabetical order:\n",
-      "Aaron\n",
-      "Bernice\n",
-      "Cody\n",
-      "\n",
-      "Here is the list in reverse alphabetical order:\n",
-      "Cody\n",
-      "Bernice\n",
-      "Aaron\n",
-      "\n",
-      "Here is the list in its original order:\n",
-      "Bernice\n",
-      "Aaron\n",
-      "Cody\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "students = ['bernice', 'aaron', 'cody']\n",
     "\n",
@@ -1093,19 +833,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['cody', 'aaron', 'bernice']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "students = ['bernice', 'aaron', 'cody']\n",
     "students.reverse()\n",
@@ -1130,20 +862,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1, 2, 3, 4]\n",
-      "[4, 3, 2, 1]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "numbers = [1, 3, 4, 2]\n",
     "\n",
@@ -1158,20 +881,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1, 2, 3, 4]\n",
-      "[1, 3, 4, 2]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "numbers = [1, 3, 4, 2]\n",
     "\n",
@@ -1182,19 +896,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2, 4, 3, 1]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "numbers = [1, 3, 4, 2]\n",
     "\n",
@@ -1214,19 +920,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "usernames = ['bernice', 'cody', 'aaron']\n",
     "user_count = len(usernames)\n",
@@ -1243,20 +941,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "We have 1 user!\n",
-      "We have 3 users!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create an empty list to hold our users.\n",
     "usernames = []\n",
@@ -1283,22 +972,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "Can't convert 'int' object to str implicitly",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-43-92e732ef190e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0muser_count\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0musernames\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"This will cause an error: \"\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0muser_count\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m: Can't convert 'int' object to str implicitly"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "usernames = ['bernice', 'cody', 'aaron']\n",
     "user_count = len(usernames)\n",
@@ -1308,19 +986,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This will work: 3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[5]\n",
     "usernames = ['bernice', 'cody', 'aaron']\n",
@@ -1411,19 +1081,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['australian cattle dog', 'labrador retriever']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "# Remove the first dog from the list.\n",
@@ -1443,19 +1105,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['border collie', 'labrador retriever']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "# Remove australian cattle dog from the list.\n",
@@ -1473,19 +1127,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['b', 'c', 'a', 'b', 'c']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "letters = ['a', 'b', 'c', 'a', 'b', 'c']\n",
     "# Remove the letter a from the list.\n",
@@ -1507,20 +1153,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "labrador retriever\n",
-      "['border collie', 'australian cattle dog']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
     "last_dog = dogs.pop()\n",
@@ -1540,20 +1177,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "border collie\n",
-      "['australian cattle dog', 'labrador retriever']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[3]\n",
     "dogs = ['border collie', 'australian cattle dog', 'labrador retriever']\n",
@@ -1607,21 +1235,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bernice\n",
-      "Cody\n",
-      "Aaron\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "usernames = ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n",
     "\n",
@@ -1641,21 +1259,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bernice\n",
-      "Cody\n",
-      "Aaron\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[5]\n",
     "usernames = ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n",
@@ -1676,23 +1284,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bernice\n",
-      "Cody\n",
-      "Aaron\n",
-      "Ever\n",
-      "Dalia\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[7,8,9]\n",
     "usernames = ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n",
@@ -1714,21 +1310,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cody\n",
-      "Aaron\n",
-      "Ever\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "usernames = ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n",
     "\n",
@@ -1748,21 +1334,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Aaron\n",
-      "Ever\n",
-      "Dalia\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "usernames = ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n",
     "\n",
@@ -1783,26 +1359,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The full copied list:\n",
-      "\t ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n",
-      "\n",
-      "Two users removed from copied list:\n",
-      "\t ['aaron', 'ever', 'dalia']\n",
-      "\n",
-      "The original list:\n",
-      "\t ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "usernames = ['bernice', 'cody', 'aaron', 'ever', 'dalia']\n",
     "\n",
@@ -1859,28 +1420,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n",
-      "6\n",
-      "7\n",
-      "8\n",
-      "9\n",
-      "10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Print out the first ten numbers.\n",
     "numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n",
@@ -1900,28 +1444,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n",
-      "6\n",
-      "7\n",
-      "8\n",
-      "9\n",
-      "10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Print the first ten numbers.\n",
     "for number in range(1,11):\n",
@@ -1937,28 +1464,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "3\n",
-      "5\n",
-      "7\n",
-      "9\n",
-      "11\n",
-      "13\n",
-      "15\n",
-      "17\n",
-      "19\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Print the first ten odd numbers.\n",
     "for number in range(1,21,2):\n",
@@ -1974,19 +1484,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create a list of the first ten numbers.\n",
     "numbers = list(range(1,11))\n",
@@ -2002,31 +1504,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The list 'numbers' has 1000000 numbers in it.\n",
-      "\n",
-      "The last ten numbers in the list are:\n",
-      "999991\n",
-      "999992\n",
-      "999993\n",
-      "999994\n",
-      "999995\n",
-      "999996\n",
-      "999997\n",
-      "999998\n",
-      "999999\n",
-      "1000000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Store the first million numbers in a list.\n",
     "numbers = list(range(1,1000001))\n",
@@ -2068,21 +1550,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Our youngest reader is 11 years old.\n",
-      "Our oldest reader is 38 years old.\n",
-      "Together, we have 149 years worth of life experience.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ages = [23, 16, 14, 28, 19, 11, 38]\n",
     "\n",
@@ -2137,28 +1609,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "4\n",
-      "9\n",
-      "16\n",
-      "25\n",
-      "36\n",
-      "49\n",
-      "64\n",
-      "81\n",
-      "100\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Store the first ten square numbers in a list.\n",
     "# Make an empty list that will hold our square numbers.\n",
@@ -2194,28 +1649,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "4\n",
-      "9\n",
-      "16\n",
-      "25\n",
-      "36\n",
-      "49\n",
-      "64\n",
-      "81\n",
-      "100\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[8]\n",
     "# Store the first ten square numbers in a list.\n",
@@ -2240,28 +1678,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "4\n",
-      "9\n",
-      "16\n",
-      "25\n",
-      "36\n",
-      "49\n",
-      "64\n",
-      "81\n",
-      "100\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# Store the first ten square numbers in a list.\n",
@@ -2303,28 +1724,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2\n",
-      "4\n",
-      "6\n",
-      "8\n",
-      "10\n",
-      "12\n",
-      "14\n",
-      "16\n",
-      "18\n",
-      "20\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make an empty list that will hold the even numbers.\n",
     "evens = []\n",
@@ -2351,28 +1755,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2\n",
-      "4\n",
-      "6\n",
-      "8\n",
-      "10\n",
-      "12\n",
-      "14\n",
-      "16\n",
-      "18\n",
-      "20\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3]\n",
     "# Make a list of the first ten even numbers.\n",
@@ -2393,21 +1780,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello, Bernice the great!\n",
-      "Hello, Aaron the great!\n",
-      "Hello, Cody the great!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Consider some students.\n",
     "students = ['bernice', 'aaron', 'cody']\n",
@@ -2435,21 +1812,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello, Bernice the great!\n",
-      "Hello, Aaron the great!\n",
-      "Hello, Cody the great!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[5,6]\n",
     "# Consider some students.\n",
@@ -2514,24 +1881,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "H\n",
-      "e\n",
-      "l\n",
-      "l\n",
-      "o\n",
-      "!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"Hello!\"\n",
     "\n",
@@ -2548,19 +1902,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"Hello world!\"\n",
     "\n",
@@ -2579,19 +1925,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('H', '!')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"Hello World!\"\n",
     "first_char = message[0]\n",
@@ -2609,19 +1947,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('Hel', 'ld!')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"Hello World!\"\n",
     "first_three = message[:3]\n",
@@ -2643,19 +1973,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"I like cats and dogs.\"\n",
     "dog_present = 'dog' in message\n",
@@ -2671,19 +1993,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "16\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"I like cats and dogs.\"\n",
     "dog_index = message.find('dog')\n",
@@ -2699,19 +2013,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "16\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2]\n",
     "message = \"I like cats and dogs, but I'd much rather own a dog.\"\n",
@@ -2728,19 +2034,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "48\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[3,4]\n",
     "message = \"I like cats and dogs, but I'd much rather own a dog.\"\n",
@@ -2759,19 +2057,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I like cats and snakes, but I'd much rather own a snake.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"I like cats and dogs, but I'd much rather own a dog.\"\n",
     "message = message.replace('dog', 'snake')\n",
@@ -2789,19 +2079,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"I like cats and dogs, but I'd much rather own a dog.\"\n",
     "number_dogs = message.count('dog')\n",
@@ -2819,19 +2101,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['I', 'like', 'cats', 'and', 'dogs,', 'but', \"I'd\", 'much', 'rather', 'own', 'a', 'dog.']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"I like cats and dogs, but I'd much rather own a dog.\"\n",
     "words = message.split(' ')\n",
@@ -2849,19 +2123,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['dog', ' cat', ' tiger', ' mouse', ' liger', ' bear']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "animals = \"dog, cat, tiger, mouse, liger, bear\"\n",
     "\n",
@@ -2959,24 +2225,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The first color is: red\n",
-      "\n",
-      "The available colors are:\n",
-      "- red\n",
-      "- green\n",
-      "- blue\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "colors = ('red', 'green', 'blue')\n",
     "print(\"The first color is: \" + colors[0])\n",
@@ -2995,22 +2248,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'tuple' object has no attribute 'append'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-37-ed1dbff53ab2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mcolors\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m'red'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'green'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'blue'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mcolors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'purple'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m: 'tuple' object has no attribute 'append'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "colors = ('red', 'green', 'blue')\n",
     "colors.append('purple')"
@@ -3034,19 +2276,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I have a dog.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "animal = 'dog'\n",
     "print(\"I have a \" + animal + \".\")"
@@ -3061,21 +2295,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I have a dog.\n",
-      "I have a cat.\n",
-      "I have a bear.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "animals = ['dog', 'cat', 'bear']\n",
     "for animal in animals:\n",
@@ -3093,19 +2317,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I have a dog.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "animal = 'dog'\n",
     "print(\"I have a %s.\" % animal)"
@@ -3122,21 +2338,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I have a dog.\n",
-      "I have a cat.\n",
-      "I have a bear.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "animals = ['dog', 'cat', 'bear']\n",
     "for animal in animals:\n",
@@ -3152,19 +2358,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I have a dog, a cat, and a bear.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "animals = ['dog', 'cat', 'bear']\n",
     "print(\"I have a %s, a %s, and a %s.\" % (animals[0], animals[1], animals[2]))"
@@ -3181,22 +2379,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "cannot concatenate 'str' and 'int' objects",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-47-1ed2c5bb2bba>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mnumber\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m23\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"My favorite number is \"\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mnumber\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;34m\".\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m: cannot concatenate 'str' and 'int' objects"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "number = 23\n",
     "print(\"My favorite number is \" + number + \".\")"
@@ -3211,19 +2398,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "My favorite number is 23.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[3]\n",
     "number = 23\n",
@@ -3239,19 +2418,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "My favorite number is 23.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[3]\n",
     "number = 23\n",
@@ -3267,19 +2438,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "My favorite numbers are 7, 23, and 42.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "numbers = [7, 23, 42]\n",
     "print(\"My favorite numbers are %d, %d, and %d.\" % (numbers[0], numbers[1], numbers[2]))"
@@ -3294,19 +2457,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "My favorite numbers are 7, 23, and 42.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[3]\n",
     "numbers = [7, 23, 42]\n",
@@ -3322,19 +2477,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Eric's favorite number is 23, and Ever's favorite number is 2.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "names = ['eric', 'ever']\n",
     "numbers = [23, 2]\n",
@@ -3467,16 +2614,6 @@
    "metadata": {},
    "source": [
     "[top](#)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- - -\n",
-    "[Previous: Variables, Strings, and Numbers](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/var_string_num.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) | \n",
-    "[Next: Introducing Functions](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/introducing_functions.ipynb)"
    ]
   },
   {

--- a/var_string_num.ipynb
+++ b/var_string_num.ipynb
@@ -13,15 +13,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Previous: Hello World](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/hello_world.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) | \n",
-    "[Next: Lists and Tuples](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/lists_tuples.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Contents\n",
     "---\n",
     "- [Variables](#Variables)\n",
@@ -38,7 +29,6 @@
     "- [Numbers](#Numbers)\n",
     "    - [Integer operations](#Integer-operations)\n",
     "    - [Floating-point numbers](#Floating-point-numbers)\n",
-    "    - [Integers in Python 2.7](#Integers-in-Python-2.7)\n",
     "    - [Exercises](#Exercises-numbers)\n",
     "    - [Challenges](#Challenges-numbers)\n",
     "- [Comments](#Comments)\n",
@@ -68,19 +58,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Python world!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"Hello Python world!\"\n",
     "print(message)"
@@ -95,20 +77,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Python world!\n",
-      "Python is my favorite language!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[5,6]\n",
     "message = \"Hello Python world!\"\n",
@@ -142,22 +115,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'mesage' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m/home/ehmatthes/development_resources/project_notes/intro_programming/notebooks/<ipython-input-12-7966723379c3>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mmessage\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"Thank you for sharing Python with the world, Guido!\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmesage\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'mesage' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "message = \"Thank you for sharing Python with the world, Guido!\"\n",
     "print(mesage)"
@@ -178,19 +140,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Thank you for sharing Python with the world, Guido!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[3]\n",
     "message = \"Thank you for sharing Python with the world, Guido!\"\n",
@@ -286,20 +240,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "eric\n",
-      "Eric"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "first_name = 'eric'\n",
     "\n",
@@ -318,22 +263,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "eric\n",
-      "Eric\n",
-      "ERIC\n",
-      "eric"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[6,8,9]\n",
     "first_name = 'eric'\n",
@@ -368,19 +302,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ada Lovelace"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "first_name = 'ada'\n",
     "last_name = 'lovelace'\n",
@@ -399,19 +325,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ada Lovelace was considered the world's first computer programmer."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[6,7,8]\n",
     "first_name = 'ada'\n",
@@ -445,57 +363,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello everyone!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Hello everyone!\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\tHello everyone!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"\\tHello everyone!\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello \teveryone!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Hello \\teveryone!\")"
    ]
@@ -509,81 +403,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello everyone!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Hello everyone!\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Hello everyone!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"\\nHello everyone!\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello \n",
-      "everyone!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Hello \\neveryone!\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "\n",
-      "Hello everyone!"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"\\n\\n\\nHello everyone!\")"
    ]
@@ -603,21 +460,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "eric \n",
-      " eric\n",
-      "eric"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "name = ' eric '\n",
     "\n",
@@ -635,21 +482,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-eric -\n",
-      "- eric-\n",
-      "-eric-"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "name = ' eric '\n",
     "\n",
@@ -713,95 +550,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(3+2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(3-2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(3*2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(3/2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(3**2)"
    ]
@@ -815,19 +612,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "14\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "standard_order = 2+3*4\n",
     "print(standard_order)"
@@ -835,19 +624,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "20\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_order = (2+3)*4\n",
     "print(my_order)"
@@ -864,19 +645,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(0.1+0.1)"
    ]
@@ -890,19 +663,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.30000000000000004\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(0.1+0.2)"
    ]
@@ -920,124 +685,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.30000000000000004\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(3*0.1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Integers in Python 2.7\n",
-    "---\n",
-    "There are a couple differences in the way Python 2 and Python 3 handle numbers. In Python 2, dividing two integers always results in an integer, while Python 3 always returns a float. This is fine when the result of your integer division is an integer, but it leads to quite different results when the answer is a decimal."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Division in Python 2.7"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Python 2.7\n",
-    "print 4/2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Python 2.7\n",
-    "print 3/2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Division in Python 3.3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.0\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Python 3.3\n",
-    "print(4/2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.5\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Python 3.3\n",
-    "print(3/2)"
    ]
   },
   {
@@ -1064,10 +718,7 @@
     "\n",
     "#### Long Decimals\n",
     "- On paper, 0.1+0.2=0.3. But you have seen that in Python, 0.1+0.2=0.30000000000000004.\n",
-    "- Find at least one other calculation that results in a long decimal like this.\n",
-    "\n",
-    "#### Python 2 or Python 3?\n",
-    "- Use integer division to show whether your Python interpeter is using Python 2 or Python 3."
+    "- Find at least one other calculation that results in a long decimal like this."
    ]
   },
   {
@@ -1088,13 +739,7 @@
     "\n",
     "#### Long Decimals - Pattern\n",
     "- On paper, 0.1+0.2=0.3. But you have seen that in Python, 0.1+0.2=0.30000000000000004.\n",
-    "- Find a number of other calculations that result in a long decimal like this. Try to find a pattern in what kinds of numbers will result in long decimals.\n",
-    "\n",
-    "#### Python 2 and Python 3\n",
-    "- Find a way to make your computer interpret 3/2 once in Python 2, and once in Python 3.\n",
-    "- (HINT) Don't spend too much time on this, unless you like reading on forums about installing from packages and what not.\n",
-    "\n",
-    "    If you just want to play around with Python 2 and Python 3, you can easily do so on [pythontutor.com](http://pythontutor.com/). Click \"Start using Online Python Tutor now\", and then delete the sample code in the text box so you can enter your own code. On that page, there is a drop-down list just below the text box that lets you select different versions of Python. Click \"Visualize Execution\" to run your code. On the next page, you can either click \"Forward\" to step through your code one line at a time, or click \"Last\" to run your entire program."
+    "- Find a number of other calculations that result in a long decimal like this. Try to find a pattern in what kinds of numbers will result in long decimals."
    ]
   },
   {
@@ -1117,19 +762,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This line is not a comment, it is code.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This line is a comment.\n",
     "print(\"This line is not a comment, it is code.\")"
@@ -1187,39 +824,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The Zen of Python, by Tim Peters\n",
-      "\n",
-      "Beautiful is better than ugly.\n",
-      "Explicit is better than implicit.\n",
-      "Simple is better than complex.\n",
-      "Complex is better than complicated.\n",
-      "Flat is better than nested.\n",
-      "Sparse is better than dense.\n",
-      "Readability counts.\n",
-      "Special cases aren't special enough to break the rules.\n",
-      "Although practicality beats purity.\n",
-      "Errors should never pass silently.\n",
-      "Unless explicitly silenced.\n",
-      "In the face of ambiguity, refuse the temptation to guess.\n",
-      "There should be one-- and preferably only one --obvious way to do it.\n",
-      "Although that way may not be obvious at first unless you're Dutch.\n",
-      "Now is better than never.\n",
-      "Although never is often better than *right* now.\n",
-      "If the implementation is hard to explain, it's a bad idea.\n",
-      "If the implementation is easy to explain, it may be a good idea.\n",
-      "Namespaces are one honking great idea -- let's do more of those!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import this"
    ]
@@ -1282,19 +891,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I can strip tabs from my name: eric\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# I learned how to strip whitespace from strings.\n",
     "name = '\\t\\teric'\n",
@@ -1369,7 +970,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.0"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/while_input.ipynb
+++ b/while_input.ipynb
@@ -13,15 +13,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Previous: If Statements](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/if_statements.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) |\n",
-    "[Next: Basic Terminal Apps](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/terminal_apps.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Contents\n",
     "===\n",
     "- [What is a `while` loop?](#What-is-a-while-loop?)\n",
@@ -31,7 +22,6 @@
     "- [Accepting user input](#Accepting-user-input)\n",
     "    - [General syntax](#General-syntax-input)\n",
     "    - [Example](#Example-input)\n",
-    "    - [Accepting input in Python 2.7](#Accepting-input-in-Python-2.7)\n",
     "    - [Exercises](#Exercises-input)\n",
     "- [Using while loops to keep your programs running](#Using-while-loops-to-keep-your-programs-running)\n",
     "    - [Exercises](#Exercises-running)\n",
@@ -101,25 +91,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You are still playing, because your power is 5.\n",
-      "You are still playing, because your power is 4.\n",
-      "You are still playing, because your power is 3.\n",
-      "You are still playing, because your power is 2.\n",
-      "You are still playing, because your power is 1.\n",
-      "\n",
-      "Oh no, your power dropped to 0! Game Over.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The player's power starts out at 5.\n",
     "power = 5\n",
@@ -217,20 +193,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Please tell me someone I should know: jessica\n",
-      "['guido', 'tim', 'jesse', 'jessica']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Start with a list containing several names.\n",
     "names = ['guido', 'tim', 'jesse']\n",
@@ -243,56 +210,6 @@
     "\n",
     "# Show that the name has been added to the list.\n",
     "print(names)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Accepting input in Python 2.7\n",
-    "---\n",
-    "In Python 3, you always use `input()`. In Python 2.7, you need to use `raw_input()`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Please tell me someone I should know: jessica\n",
-      "['guido', 'tim', 'jesse', 'jessica']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# The same program, in Python 2.7\n",
-    "\n",
-    "# Start with a list containing several names.\n",
-    "names = ['guido', 'tim', 'jesse']\n",
-    "\n",
-    "# Ask the user for a name.\n",
-    "new_name = raw_input(\"Please tell me someone I should know: \")\n",
-    "\n",
-    "# Add the new name to our list.\n",
-    "names.append(new_name)\n",
-    "\n",
-    "# Show that the name has been added to the list.\n",
-    "print(names)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The function `input()` will work in Python 2.7, but it's not good practice to use it. When you use the `input()` function in Python 2.7, Python runs the code that's entered. This is fine in controlled situations, but it's not a very safe practice overall.\n",
-    "\n",
-    "If you're using Python 3, you have to use `input()`. If you're using Python 2.7, use `raw_input()`."
    ]
   },
   {
@@ -328,24 +245,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Please tell me someone I should know, or enter 'quit': guido\n",
-      "Please tell me someone I should know, or enter 'quit': jesse\n",
-      "Please tell me someone I should know, or enter 'quit': jessica\n",
-      "Please tell me someone I should know, or enter 'quit': tim\n",
-      "Please tell me someone I should know, or enter 'quit': quit\n",
-      "['guido', 'jesse', 'jessica', 'tim', 'quit']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Start with an empty list. You can 'seed' the list with\n",
     "#  some predefined values if you like.\n",
@@ -375,24 +279,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Please tell me someone I should know, or enter 'quit': guido\n",
-      "Please tell me someone I should know, or enter 'quit': jesse\n",
-      "Please tell me someone I should know, or enter 'quit': jessica\n",
-      "Please tell me someone I should know, or enter 'quit': tim\n",
-      "Please tell me someone I should know, or enter 'quit': quit\n",
-      "['guido', 'jesse', 'jessica', 'tim']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[15,16]\n",
     "# Start with an empty list. You can 'seed' the list with\n",
@@ -451,51 +342,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Welcome to the nature center. What would you like to do?\n",
-      "\n",
-      "[1] Enter 1 to take a bicycle ride.\n",
-      "[2] Enter 2 to go for a run.\n",
-      "[3] Enter 3 to climb a mountain.\n",
-      "[q] Enter q to quit.\n",
-      "\n",
-      "What would you like to do? 1\n",
-      "\n",
-      "Here's a bicycle. Have fun!\n",
-      "\n",
-      "\n",
-      "[1] Enter 1 to take a bicycle ride.\n",
-      "[2] Enter 2 to go for a run.\n",
-      "[3] Enter 3 to climb a mountain.\n",
-      "[q] Enter q to quit.\n",
-      "\n",
-      "What would you like to do? 3\n",
-      "\n",
-      "Here's a map. Can you leave a trip plan for us?\n",
-      "\n",
-      "\n",
-      "[1] Enter 1 to take a bicycle ride.\n",
-      "[2] Enter 2 to go for a run.\n",
-      "[3] Enter 3 to climb a mountain.\n",
-      "[q] Enter q to quit.\n",
-      "\n",
-      "What would you like to do? q\n",
-      "\n",
-      "Thanks for playing. See you later.\n",
-      "\n",
-      "Thanks again, bye now.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Give the user some context.\n",
     "print(\"\\nWelcome to the nature center. What would you like to do?\")\n",
@@ -539,51 +390,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Welcome to the nature center. What would you like to do?\n",
-      "\n",
-      "[1] Enter 1 to take a bicycle ride.\n",
-      "[2] Enter 2 to go for a run.\n",
-      "[3] Enter 3 to climb a mountain.\n",
-      "[q] Enter q to quit.\n",
-      "\n",
-      "What would you like to do? 1\n",
-      "\n",
-      "Here's a bicycle. Have fun!\n",
-      "\n",
-      "\n",
-      "[1] Enter 1 to take a bicycle ride.\n",
-      "[2] Enter 2 to go for a run.\n",
-      "[3] Enter 3 to climb a mountain.\n",
-      "[q] Enter q to quit.\n",
-      "\n",
-      "What would you like to do? 3\n",
-      "\n",
-      "Here's a map. Can you leave a trip plan for us?\n",
-      "\n",
-      "\n",
-      "[1] Enter 1 to take a bicycle ride.\n",
-      "[2] Enter 2 to go for a run.\n",
-      "[3] Enter 3 to climb a mountain.\n",
-      "[q] Enter q to quit.\n",
-      "\n",
-      "What would you like to do? q\n",
-      "\n",
-      "Thanks for playing. See you later.\n",
-      "\n",
-      "Thanks again, bye now.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[2,3,4,5,6,7,8,9,10,30,31,32,33,34,35]\n",
     "# Define the actions for each choice we want to offer.\n",
@@ -654,30 +465,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Confirming user Daria...confirmed!\n",
-      "Confirming user Clarence...confirmed!\n",
-      "Confirming user Billy...confirmed!\n",
-      "Confirming user Ada...confirmed!\n",
-      "\n",
-      "Unconfirmed users:\n",
-      "\n",
-      "Confirmed users:\n",
-      "- Daria\n",
-      "- Clarence\n",
-      "- Billy\n",
-      "- Ada\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Start with a list of unconfirmed users, and an empty list of confirmed users.\n",
     "unconfirmed_users = ['ada', 'billy', 'clarence', 'daria']\n",
@@ -712,30 +504,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Confirming user Ada...confirmed!\n",
-      "Confirming user Billy...confirmed!\n",
-      "Confirming user Clarence...confirmed!\n",
-      "Confirming user Daria...confirmed!\n",
-      "\n",
-      "Unconfirmed users:\n",
-      "\n",
-      "Confirmed users:\n",
-      "- Ada\n",
-      "- Billy\n",
-      "- Clarence\n",
-      "- Daria\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[10]\n",
     "# Start with a list of unconfirmed users, and an empty list of confirmed users.\n",
@@ -832,23 +605,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "###highlight=[7]\n",
     "current_number = 1\n",
@@ -966,16 +727,6 @@
    "metadata": {},
    "source": [
     "[top](#)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- - -\n",
-    "[Previous: If Statements](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/if_statements.ipynb) | \n",
-    "[Home](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/index.ipynb) |\n",
-    "[Next: Basic Terminal Apps](http://nbviewer.ipython.org/urls/raw.github.com/ehmatthes/intro_programming/master/notebooks/terminal_apps.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
The breadcrumb links from the orignal versions of these notebooks
linked back to the orignal author's website.  Since we are using
our own host for these modified notebooks and the entire course
will not be used, we have decided to remove the links.

Addtionally, we have removed all Python 2 references from the
notebooks as our course will focus on Python 3.

The notebooks have also been set to target Python version 3.6.1
as that is the version our host is using.

Finally, outputs have been cleared so they do not show up prior to running our code.